### PR TITLE
Fix hardcoded .com in URL string

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -3,4 +3,4 @@ username=<user>
 password=<pass>
 domainToUpdate=<your_domains>
 
-echo url="https://$username:$password@domains.google.com/nic/update?hostname=$domainToUpdate.com&myip=$externalIp" | curl -k -o ./response.log -K -
+echo url="https://$username:$password@domains.google.com/nic/update?hostname=$domainToUpdate&myip=$externalIp" | curl -k -o ./response.log -K -


### PR DESCRIPTION
The `.com` should be specified in line 4: `domainToUpdate=<your_domains>` and therefore will cause issues if specified in line 6 as well.